### PR TITLE
lib/modules: always call strip for mkRemove

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -764,7 +764,7 @@ rec {
         # Sort mkOrder properties.
         defs''' =
           # Avoid sorting if we don't have to.
-          if any (def: def.value._type or "" == "order") defs''.values
+          if any (def: let _type = def.value._type or ""; in _type == "order" || _type == "remove") defs''.values
           then sortProperties defs''.values
           else defs''.values;
       in {

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -338,6 +338,9 @@ checkConfigOutput '^\[ "before1" "before2" "default1" "default2" "after1" "after
 # mkRemove
 checkConfigOutput '^\[ "before2" "default2" "after1" "after2" \]$' 'config.result' \
   ./list/define-list.nix ./list/default-order.nix ./list/after.nix ./list/before.nix ./list/remove.nix
+# mkRemove with no mkOrder
+checkConfigOutput '^\[ "default2" \]$' 'config.result' \
+  ./list/define-list.nix ./list/default-order.nix ./list/remove.nix
 
 cat <<EOF
 ====== module tests ======


### PR DESCRIPTION
###### Description of changes

Before this patch, strip in sortProperties is not called if there is
no mkOrder (or its variants) in the defined value, which leads to the
failure of type check.

A test is also added. I don't run it, but it should pass.

###### Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

